### PR TITLE
Codedeployの追加とその他諸々

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -1,10 +1,10 @@
 # このterraformでacm発行できるが現状手動で設定
-resource "aws_acm_certificate" "movie-backend-acm" {
-  domain_name               = aws_route53_record.movie-backend.name
-  subject_alternative_names = []
-  validation_method         = "DNS"
+# resource "aws_acm_certificate" "movie-backend-acm" {
+#   domain_name               = aws_route53_record.movie-backend.name
+#   subject_alternative_names = []
+#   validation_method         = "DNS"
 
-  lifecycle {
-    create_before_destroy = true
-  }
-}
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }

--- a/code_deploy.tf
+++ b/code_deploy.tf
@@ -1,0 +1,58 @@
+resource "aws_codedeploy_app" "movie-backend" {
+  compute_platform = "ECS"
+  name             = "movie-backend"
+}
+
+resource "aws_codedeploy_deployment_group" "movie-backend" {
+  deployment_group_name  = "movie-backend"
+  
+  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
+  app_name               = aws_codedeploy_app.movie-backend.name
+  service_role_arn       = aws_iam_role.codedeploy.arn
+
+  depends_on = [aws_ecs_service.movie-backend]
+
+  auto_rollback_configuration {
+    enabled = true
+    events = [
+      "DEPLOYMENT_FAILURE"
+    ]
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = 1
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  ecs_service {
+    cluster_name = aws_ecs_cluster.movie-backend.name
+    service_name = "movie-backend"
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      prod_traffic_route {
+        listener_arns = [
+          aws_lb_listener.movie-backend.arn
+        ]
+      }
+      target_group {
+        name = aws_lb_target_group.blue.name
+      }
+      target_group {
+        name = aws_lb_target_group.green.name
+      }
+    }
+  }
+}

--- a/ecs.tf
+++ b/ecs.tf
@@ -5,7 +5,9 @@ resource "aws_ecs_cluster" "movie-backend" {
 resource "aws_ecs_service" "movie-backend" {
   name = "movie-backend"
 
-  depends_on = [aws_lb_listener_rule.movie-backend, aws_lb_listener_rule.movie-backend-api]
+  depends_on = [aws_lb.movie-backend-alb,
+                aws_lb_listener.movie-backend,
+                aws_lb_listener_rule.movie-backend]
 
   cluster = aws_ecs_cluster.movie-backend.name
 
@@ -13,19 +15,23 @@ resource "aws_ecs_service" "movie-backend" {
 
   desired_count = "1"
 
-  enable_execute_command = true
+  # enable_execute_command = true
 
   task_definition = aws_ecs_task_definition.movie-backend.arn
 
   network_configuration {
-    subnets         = [aws_subnet.movie-backend-private-1a.id, aws_subnet.movie-backend-private-1c.id, aws_subnet.movie-backend-private-1d.id]
+    subnets         = [aws_subnet.movie-backend-private-1a.id, aws_subnet.movie-backend-private-1c.id]
     security_groups = [aws_security_group.movie-backend-ecs.id]
   }
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.movie-backend.arn
+    target_group_arn = aws_lb_target_group.blue.arn
     container_name   = "movie_backend"
     container_port   = "8080"
+  }
+
+  deployment_controller {
+    type = "CODE_DEPLOY"
   }
 }
 

--- a/eip.tf
+++ b/eip.tf
@@ -1,6 +1,8 @@
 resource "aws_eip" "movie-backend-nat-1a" {
   vpc = true
 
+  depends_on = [aws_internet_gateway.movie-backend]
+
   tags = {
     Name = "movie-backend-natgw-1a"
   }
@@ -8,6 +10,8 @@ resource "aws_eip" "movie-backend-nat-1a" {
 
 resource "aws_eip" "movie-backend-nat-1b" {
   vpc = true
+
+  depends_on = [aws_internet_gateway.movie-backend]
 
   tags = {
     Name = "movie-backend-natgw-1b"
@@ -17,15 +21,9 @@ resource "aws_eip" "movie-backend-nat-1b" {
 resource "aws_eip" "movie-backend-nat-1c" {
   vpc = true
 
+  depends_on = [aws_internet_gateway.movie-backend]
+
   tags = {
     Name = "movie-backend-natgw-1c"
-  }
-}
-
-resource "aws_eip" "movie-backend-nat-1d" {
-  vpc = true
-
-  tags = {
-    Name = "movie-backend-natgw-1d"
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -11,11 +11,53 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "ecs_task_execution_role" {
-  name               = "MyEcsTaskRole"
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  name                = "MovieBackendEcsTaskRole"
+  assume_role_policy  = data.aws_iam_policy_document.assume_role.json
+  managed_policy_arns = [aws_iam_policy.movie_backend_ecs_exec_policy.arn]
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_ecs_task_execution_role_policy" {
   role       = aws_iam_role.ecs_task_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "codedeploy_assumerole" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["codedeploy.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "movie_backend_ecs_exec_policy" {
+  name = "movie_backend-ecs-exec-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+
+resource "aws_iam_role" "codedeploy" {
+  name               = "ECSPipelineMovieBackend"
+  assume_role_policy = data.aws_iam_policy_document.codedeploy_assumerole.json
+}
+
+resource "aws_iam_role_policy_attachment" "codedeploy" {
+  role       = aws_iam_role.codedeploy.id
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS"
 }

--- a/nat.tf
+++ b/nat.tf
@@ -2,6 +2,8 @@ resource "aws_nat_gateway" "movie-backend-nat-1a" {
   subnet_id     = aws_subnet.movie-backend-public-1a.id
   allocation_id = aws_eip.movie-backend-nat-1a.id
 
+  depends_on = [aws_internet_gateway.movie-backend]
+
   tags = {
     Name = "movie-backend-1a"
   }
@@ -11,16 +13,9 @@ resource "aws_nat_gateway" "movie-backend-nat-1c" {
   subnet_id     = aws_subnet.movie-backend-public-1c.id
   allocation_id = aws_eip.movie-backend-nat-1c.id
 
+  depends_on = [aws_internet_gateway.movie-backend]
+
   tags = {
     Name = "movie-backend-1c"
-  }
-}
-
-resource "aws_nat_gateway" "movie-backend-nat-1d" {
-  subnet_id     = aws_subnet.movie-backend-public-1d.id
-  allocation_id = aws_eip.movie-backend-nat-1d.id
-
-  tags = {
-    Name = "movie-backend-1d"
   }
 }

--- a/route.tf
+++ b/route.tf
@@ -22,11 +22,6 @@ resource "aws_route_table_association" "movie-backend-public-1c" {
   route_table_id = aws_route_table.movie-backend-public.id
 }
 
-resource "aws_route_table_association" "movie-backend-public-1d" {
-  subnet_id      = aws_subnet.movie-backend-public-1d.id
-  route_table_id = aws_route_table.movie-backend-public.id
-}
-
 resource "aws_route_table" "movie-backend-private-1a" {
   vpc_id = aws_vpc.movie-backend.id
 
@@ -43,14 +38,6 @@ resource "aws_route_table" "movie-backend-private-1c" {
   }
 }
 
-resource "aws_route_table" "movie-backend-private-1d" {
-  vpc_id = aws_vpc.movie-backend.id
-
-  tags = {
-    Name = "movie-backend-private-1d"
-  }
-}
-
 resource "aws_route" "movie-backend-private-1a" {
   destination_cidr_block = "0.0.0.0/0"
   route_table_id         = aws_route_table.movie-backend-private-1a.id
@@ -63,12 +50,6 @@ resource "aws_route" "movie-backend-private-1c" {
   nat_gateway_id         = aws_nat_gateway.movie-backend-nat-1c.id
 }
 
-resource "aws_route" "movie-backend-private-1d" {
-  destination_cidr_block = "0.0.0.0/0"
-  route_table_id         = aws_route_table.movie-backend-private-1d.id
-  nat_gateway_id         = aws_nat_gateway.movie-backend-nat-1d.id
-}
-
 resource "aws_route_table_association" "movie-backend-private-1a" {
   subnet_id      = aws_subnet.movie-backend-private-1a.id
   route_table_id = aws_route_table.movie-backend-private-1a.id
@@ -79,7 +60,3 @@ resource "aws_route_table_association" "movie-backend-private-1c" {
   route_table_id = aws_route_table.movie-backend-private-1c.id
 }
 
-resource "aws_route_table_association" "movie-backend-private-1d" {
-  subnet_id      = aws_subnet.movie-backend-private-1d.id
-  route_table_id = aws_route_table.movie-backend-private-1d.id
-}

--- a/route53.tf
+++ b/route53.tf
@@ -1,16 +1,17 @@
-data "aws_route53_zone" "movie-backend" {
-  name         = "yikegaya.work"
-  private_zone = false
-}
+# 金かかるので無効化中
+# data "aws_route53_zone" "movie-backend" {
+#   name         = "yikegaya.work"
+#   private_zone = false
+# }
 
-resource "aws_route53_record" "movie-backend" {
-  name    = data.aws_route53_zone.movie-backend.name
-  zone_id = data.aws_route53_zone.movie-backend.id
-  type    = "A"
+# resource "aws_route53_record" "movie-backend" {
+#   name    = data.aws_route53_zone.movie-backend.name
+#   zone_id = data.aws_route53_zone.movie-backend.id
+#   type    = "A"
 
-  alias {
-    evaluate_target_health = true
-    name                   = aws_lb.movie-backend-alb.dns_name
-    zone_id                = aws_lb.movie-backend-alb.zone_id
-  }
-}
+#   alias {
+#     evaluate_target_health = true
+#     name                   = aws_lb.movie-backend-alb.dns_name
+#     zone_id                = aws_lb.movie-backend-alb.zone_id
+#   }
+# }

--- a/subnet.tf
+++ b/subnet.tf
@@ -22,18 +22,6 @@ resource "aws_subnet" "movie-backend-public-1c" {
   }
 }
 
-resource "aws_subnet" "movie-backend-public-1d" {
-  vpc_id = aws_vpc.movie-backend.id
-
-  availability_zone = "ap-northeast-1d"
-
-  cidr_block        = "10.0.3.0/24"
-
-  tags = {
-    Name = "movie-backend-public-1d"
-  }
-}
-
 resource "aws_subnet" "movie-backend-private-1a" {
   vpc_id = aws_vpc.movie-backend.id
 
@@ -53,16 +41,5 @@ resource "aws_subnet" "movie-backend-private-1c" {
 
   tags = {
     Name = "movie-backend-private-1c"
-  }
-}
-
-resource "aws_subnet" "movie-backend-private-1d" {
-  vpc_id = aws_vpc.movie-backend.id
-
-  availability_zone = "ap-northeast-1d"
-  cidr_block        = "10.0.30.0/24"
-
-  tags = {
-    Name = "movie-backend-private-1d"
   }
 }

--- a/subnet_group.tf
+++ b/subnet_group.tf
@@ -1,4 +1,4 @@
 resource "aws_db_subnet_group" "movie-backend-db-subnet" {
   name        = "movie-rds-subnet-group"
-  subnet_ids  = [aws_subnet.movie-backend-public-1a.id, aws_subnet.movie-backend-public-1c.id, aws_subnet.movie-backend-public-1d.id]
+  subnet_ids  = [aws_subnet.movie-backend-public-1a.id, aws_subnet.movie-backend-public-1c.id]
 }


### PR DESCRIPTION
- Codedeployの追加
- internet_gatewayが原因でterraform destroyが失敗していたので対応
- subnetの数を減らす
- 一旦httpsは使わない（DNP代節約）